### PR TITLE
Fix missing module and type errors

### DIFF
--- a/app/api/fairwork/[awardCode]/[classificationCode]/route.ts
+++ b/app/api/fairwork/[awardCode]/[classificationCode]/route.ts
@@ -1,19 +1,20 @@
-import { NextResponse } from 'next/server';
-import type { NextRequest } from 'next/server';
-import { z } from 'zod';
+import { NextApiRequest, NextApiResponse } from 'next';
+import { FairWorkService } from '@/lib/fairwork';
 
-import { getAwardClassificationDetails } from '@/lib/fairwork';
+const fairWorkService = new FairWorkService();
 
-export async function GET(
-  request: NextRequest,
-  { params }: { params: { awardCode: string; classificationCode: string } }
-): Promise<NextResponse> {
-  const { awardCode, classificationCode } = params;
+export default async function handler(req: NextApiRequest, res: NextApiResponse): Promise<void> {
+  const { awardCode, classificationCode } = req.query;
+
+  if (typeof awardCode !== 'string' || typeof classificationCode !== 'string') {
+    res.status(400).json({ error: 'Invalid award or classification code' });
+    return;
+  }
 
   try {
-    const details = await getAwardClassificationDetails(awardCode, classificationCode);
-    return NextResponse.json(details);
+    const classification = await fairWorkService.getClassification(awardCode, classificationCode);
+    res.status(200).json(classification);
   } catch (error) {
-    return NextResponse.json({ error: 'Failed to fetch details' }, { status: 500 });
+    res.status(500).json({ error: 'Failed to fetch classification' });
   }
 }

--- a/app/api/fairwork/[awardCode]/[classificationCode]/route.ts
+++ b/app/api/fairwork/[awardCode]/[classificationCode]/route.ts
@@ -1,18 +1,19 @@
-import { NextApiRequest, NextApiResponse } from 'next';
-import { getClassificationDetails } from '@/lib/services/fairwork/fairwork.client';
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+import { z } from 'zod';
 
-export default async function handler(req: NextApiRequest, res: NextApiResponse) {
-  const { awardCode, classificationCode } = req.query;
+import { getAwardClassificationDetails } from '@/lib/fairwork';
 
-  if (req.method === 'GET') {
-    try {
-      const classificationDetails = await getClassificationDetails(awardCode as string, classificationCode as string);
-      res.status(200).json(classificationDetails);
-    } catch (error) {
-      res.status(500).json({ error: 'Failed to fetch classification details' });
-    }
-  } else {
-    res.setHeader('Allow', ['GET']);
-    res.status(405).end(`Method ${req.method} Not Allowed`);
+export async function GET(
+  request: NextRequest,
+  { params }: { params: { awardCode: string; classificationCode: string } }
+): Promise<NextResponse> {
+  const { awardCode, classificationCode } = params;
+
+  try {
+    const details = await getAwardClassificationDetails(awardCode, classificationCode);
+    return NextResponse.json(details);
+  } catch (error) {
+    return NextResponse.json({ error: 'Failed to fetch details' }, { status: 500 });
   }
 }

--- a/app/editor/page.tsx
+++ b/app/editor/page.tsx
@@ -2,7 +2,7 @@
 
 import { PuckEditor } from '@/components/editor/puck-editor';
 import { useCallback } from 'react';
-import { useToast } from '@/hooks/use-toast';
+import { useToast } from '@/components/ui/use-toast';
 
 const initialData = {
   content: [

--- a/hooks/use-toast.ts
+++ b/hooks/use-toast.ts
@@ -1,3 +1,5 @@
+"use client";
+
 // Inspired by react-hot-toast library
 import { useState, useEffect, useCallback } from 'react';
 import { Toast } from '@/components/ui/toast';

--- a/lib/error-tracking.ts
+++ b/lib/error-tracking.ts
@@ -1,4 +1,4 @@
-import { toast } from '@/components/ui/use-toast';
+import { toast } from '@/hooks/use-toast';
 import punycode from 'punycode2';
 
 interface ErrorContext {

--- a/next.config.js
+++ b/next.config.js
@@ -43,6 +43,7 @@ const nextConfig = {
   },
   webpack: (config, { }) => {
     config.resolve.alias['@/hooks'] = path.join(__dirname, 'hooks');
+    config.resolve.alias['@/lib/fairwork'] = path.join(__dirname, 'lib/services/fairwork.ts'); // P923e
     // Suppress punycode warning
     config.ignoreWarnings = [
       { module: /node_modules\/punycode/ }


### PR DESCRIPTION
Update the `GET` export in `app/api/fairwork/[awardCode]/[classificationCode]/route.ts` to use the correct type for the function's second argument.

Correct the import statement for `toast` in `lib/error-tracking.ts` from `@/components/ui/use-toast` to `@/hooks/use-toast`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Arcane-Fly/crm7/pull/92?shareId=3ab70185-e778-4849-b31e-de9fa847289b).